### PR TITLE
Add support for shared files in Google Drive

### DIFF
--- a/source/interfaces/GoogleDriveInterface.js
+++ b/source/interfaces/GoogleDriveInterface.js
@@ -46,11 +46,16 @@ class GoogleDriveInterface extends FileSystemInterface {
                 // Root dir
                 const allIDs = files.map(file => file.id);
                 files.forEach(file => {
-                    file.parents.forEach(parentID => {
-                        if (allIDs.indexOf(parentID) === -1) {
-                            selectedFiles.push(file);
-                        }
-                    });
+                    // Shared files have no parents
+                    if (file.shared && file.parents && file.parents.length === 0) {
+                        selectedFiles.push(file);
+                    } else {
+                        file.parents.forEach(parentID => {
+                            if (allIDs.indexOf(parentID) === -1) {
+                                selectedFiles.push(file);
+                            }
+                        });
+                    }
                 });
             } else {
                 // Sub dir


### PR DESCRIPTION
Shared files are (currently) not shown in the google drive manager since they might not have parents.

Added a check to see if the parents array is empty & the shared attribute is true.